### PR TITLE
Make the reject attribute note consistent

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -490,7 +490,7 @@ The value for the iptables --jump parameter. Normal values are:
 
 But any valid chain name is allowed.
 
-For the values ACCEPT, DROP and REJECT you must use the generic
+For the values ACCEPT, DROP, and REJECT, you must use the generic
 'action' parameter. This is to enfore the use of generic parameters where
 possible for maximum cross-platform modelling.
 
@@ -557,7 +557,7 @@ this boolean will enable randomized port mapping.
 
 ##### `reject`
 
-When combined with jump => "REJECT" you can specify a different icmp
+When combined with action => "REJECT" you can specify a different icmp
 response to be sent back to the packet sender.
 
 ##### `log_level`


### PR DESCRIPTION
The `reject` attribute noted `jump => 'REJECT'`. But, the `jump` attribute notes that "for the values ACCEPT, DROP, and REJECT, you must use the generic `action` parameter." (Also, added some commas...)